### PR TITLE
Fix fatal error when running migrate

### DIFF
--- a/application/libraries/CILogger.php
+++ b/application/libraries/CILogger.php
@@ -84,6 +84,12 @@ class CILogger {
      * If we are logging this run, write profiling results to DB.
      */
     function resolve_profiling() {
+        // Don't bother profiling when we are outside of a session since we're
+        // missing most of the relevant information.
+        if (!$this->CI->session) {
+            return;
+        }
+
         // If we should log this run
         if (rand(0, 99) < $this->log_frequency) {
             // Total consumed memory


### PR DESCRIPTION
`php index.php migrate` results in a fatal error because the session is
undefined. From what I can tell, the profiler assumes the session is available,
which doesn't make sense for system actions like a database migration. To avoid
the issue, we just avoid the profiler when we're outside of a session.

https://github.com/anup-khanal-reisys/logger-codeigniter/issues/1