### PR TITLE
Bump php-fpm to 7.3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.0-fpm
+FROM php:7.3-fpm
 
 ARG APP_DIR=/var/www
 


### PR DESCRIPTION
I was having trouble getting composer running in docker. It seemed like the composer.lock was generated with php 7.3, which matches what's in [datagov-deploy](https://github.com/GSA/datagov-deploy).